### PR TITLE
Add project creation API foundation

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -47,10 +47,10 @@ Status: 80% Complete
 Spec: COMPLETED ✅
 Plan: COMPLETED ✅
 Tasks: COMPLETED ✅ (96 tasks)
-Backend: NOT STARTED
+Backend: IN PROGRESS (core CRUD foundation in API)
 Frontend: NOT STARTED
 Database: NOT STARTED
-Status: 30% Complete (Planning Done)
+Status: 35% Complete (Backend foundation underway)
 ```
 
 **Contractor Onboarding** 
@@ -121,6 +121,11 @@ Status: 25% Complete (Planning Done)
 - Set up project documentation
 - Created spec-kit commands
 - Organized vision into actionable features
+
+#### 2025-01-18
+- Implemented project creation backend foundation (Pydantic models, Supabase service, CRUD endpoints)
+- Wired new projects router into FastAPI app
+- Updated progress tracker to reflect backend work in progress
 
 ---
 

--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 import logging
 from .config import settings
-from .routers import auth, properties
+from .routers import auth, properties, projects
 from .services.supabase import supabase_service
 from .middleware.rate_limit import rate_limit_middleware
 
@@ -65,6 +65,12 @@ app.include_router(
     properties.router,
     prefix="/api",
     tags=["Properties"]
+)
+
+app.include_router(
+    projects.router,
+    prefix="/api",
+    tags=["Projects"]
 )
 
 # Health check endpoint

--- a/api/models/project.py
+++ b/api/models/project.py
@@ -1,0 +1,284 @@
+"""Pydantic models that power the project creation API."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field, root_validator, validator
+
+
+class ProjectCategory(str, Enum):
+    """Supported maintenance project categories."""
+
+    PLUMBING = "plumbing"
+    ELECTRICAL = "electrical"
+    HVAC = "hvac"
+    ROOFING = "roofing"
+    PAINTING = "painting"
+    LANDSCAPING = "landscaping"
+    CARPENTRY = "carpentry"
+    GENERAL_MAINTENANCE = "general_maintenance"
+    OTHER = "other"
+
+
+class ProjectUrgency(str, Enum):
+    """How quickly the work must begin."""
+
+    EMERGENCY = "emergency"
+    URGENT = "urgent"
+    ROUTINE = "routine"
+    SCHEDULED = "scheduled"
+
+
+class ProjectStatus(str, Enum):
+    """Lifecycle status for a project."""
+
+    DRAFT = "draft"
+    OPEN_FOR_BIDS = "open_for_bids"
+    BIDDING_CLOSED = "bidding_closed"
+    AWARDED = "awarded"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class BudgetRange(str, Enum):
+    """Standard budget ranges presented to property managers."""
+
+    UNDER_500 = "under_500"
+    BETWEEN_500_1000 = "500_1000"
+    BETWEEN_1000_5000 = "1000_5000"
+    BETWEEN_5000_10000 = "5000_10000"
+    OVER_10000 = "over_10000"
+    OPEN = "open"
+
+
+class VirtualAccessInfo(BaseModel):
+    """Optional information that helps contractors access the property."""
+
+    gate_code: Optional[str] = Field(None, max_length=50)
+    lockbox_code: Optional[str] = Field(None, max_length=50)
+    key_location: Optional[str] = Field(None, max_length=255)
+    onsite_contact_name: Optional[str] = Field(None, max_length=255)
+    onsite_contact_phone: Optional[str] = Field(
+        None,
+        regex=r"^\+?1?\d{9,15}$",
+        description="International E.164 formatted phone number",
+    )
+    parking_instructions: Optional[str] = Field(None, max_length=500)
+    work_hours: Optional[str] = Field(None, max_length=255)
+    hazards: Optional[str] = Field(None, max_length=500)
+    pets_on_property: Optional[bool] = None
+
+    class Config:
+        anystr_strip_whitespace = True
+
+
+class ProjectBase(BaseModel):
+    """Shared fields used for create/update operations."""
+
+    property_id: UUID
+    title: str = Field(..., min_length=3, max_length=100)
+    description: str = Field(..., min_length=30, max_length=2000)
+    category: ProjectCategory
+    urgency: ProjectUrgency = ProjectUrgency.ROUTINE
+    bid_deadline: datetime
+    preferred_start_date: Optional[date] = None
+    completion_deadline: Optional[date] = None
+    budget_min: Optional[float] = Field(None, ge=0)
+    budget_max: Optional[float] = Field(None, ge=0)
+    budget_range: Optional[BudgetRange] = None
+    insurance_required: bool = True
+    license_required: bool = True
+    minimum_bids: int = Field(3, ge=1, le=20)
+    is_open_bidding: bool = False
+    virtual_access: Optional[VirtualAccessInfo] = None
+    location_details: Optional[str] = Field(None, max_length=500)
+    special_conditions: Optional[str] = Field(None, max_length=1000)
+
+    @validator("bid_deadline")
+    def validate_bid_deadline(cls, value: datetime) -> datetime:
+        now = datetime.utcnow()
+        if value <= now:
+            raise ValueError("Bid deadline must be in the future")
+        max_deadline = now + timedelta(days=7)
+        if value > max_deadline:
+            raise ValueError("Bid deadline cannot be more than 7 days out")
+        return value
+
+    @validator("preferred_start_date", "completion_deadline", pre=True)
+    def parse_dates(cls, value):
+        if isinstance(value, str):
+            return date.fromisoformat(value)
+        return value
+
+    @root_validator
+    def validate_dates(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        preferred_start = values.get("preferred_start_date")
+        completion = values.get("completion_deadline")
+        bid_deadline = values.get("bid_deadline")
+
+        if preferred_start and preferred_start < datetime.utcnow().date():
+            raise ValueError("Preferred start date cannot be in the past")
+
+        if completion and preferred_start and completion < preferred_start:
+            raise ValueError("Completion deadline must be after start date")
+
+        if preferred_start and bid_deadline.date() > preferred_start:
+            raise ValueError("Bid deadline must be on or before preferred start date")
+
+        budget_min = values.get("budget_min")
+        budget_max = values.get("budget_max")
+        if budget_min is not None and budget_max is not None and budget_min > budget_max:
+            raise ValueError("Minimum budget cannot exceed maximum budget")
+
+        return values
+
+
+class ProjectCreate(ProjectBase):
+    """Payload for creating a project."""
+
+    status: ProjectStatus = ProjectStatus.DRAFT
+    publish: bool = Field(
+        False,
+        description="If true the project will immediately be marked open for bids",
+    )
+
+
+class ProjectUpdate(BaseModel):
+    """Payload for updating an existing project."""
+
+    title: Optional[str] = Field(None, min_length=3, max_length=100)
+    description: Optional[str] = Field(None, min_length=30, max_length=2000)
+    category: Optional[ProjectCategory] = None
+    urgency: Optional[ProjectUrgency] = None
+    bid_deadline: Optional[datetime] = None
+    preferred_start_date: Optional[date] = None
+    completion_deadline: Optional[date] = None
+    budget_min: Optional[float] = Field(None, ge=0)
+    budget_max: Optional[float] = Field(None, ge=0)
+    budget_range: Optional[BudgetRange] = None
+    insurance_required: Optional[bool] = None
+    license_required: Optional[bool] = None
+    minimum_bids: Optional[int] = Field(None, ge=1, le=20)
+    is_open_bidding: Optional[bool] = None
+    virtual_access: Optional[VirtualAccessInfo] = None
+    location_details: Optional[str] = Field(None, max_length=500)
+    special_conditions: Optional[str] = Field(None, max_length=1000)
+    status: Optional[ProjectStatus] = None
+
+    @validator("bid_deadline")
+    def validate_optional_deadline(cls, value: datetime) -> datetime:
+        if value <= datetime.utcnow():
+            raise ValueError("Bid deadline must be in the future")
+        max_deadline = datetime.utcnow() + timedelta(days=7)
+        if value > max_deadline:
+            raise ValueError("Bid deadline cannot be more than 7 days out")
+        return value
+
+    @root_validator
+    def validate_budget_and_dates(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        budget_min = values.get("budget_min")
+        budget_max = values.get("budget_max")
+        if budget_min is not None and budget_max is not None and budget_min > budget_max:
+            raise ValueError("Minimum budget cannot exceed maximum budget")
+
+        preferred_start = values.get("preferred_start_date")
+        completion = values.get("completion_deadline")
+        if preferred_start and preferred_start < datetime.utcnow().date():
+            raise ValueError("Preferred start date cannot be in the past")
+        if completion and preferred_start and completion < preferred_start:
+            raise ValueError("Completion deadline must be after start date")
+        return values
+
+
+class Project(BaseModel):
+    """Representation of a project returned to the client."""
+
+    id: UUID
+    property_id: UUID
+    created_by: UUID
+    title: str
+    description: str
+    category: ProjectCategory
+    urgency: ProjectUrgency
+    bid_deadline: datetime
+    preferred_start_date: Optional[date]
+    completion_deadline: Optional[date]
+    budget_min: Optional[float]
+    budget_max: Optional[float]
+    budget_range: Optional[BudgetRange]
+    insurance_required: bool
+    license_required: bool
+    minimum_bids: int
+    is_open_bidding: bool
+    virtual_access: Optional[VirtualAccessInfo]
+    location_details: Optional[str]
+    special_conditions: Optional[str]
+    status: ProjectStatus
+    view_count: int = 0
+    bid_count: int = 0
+    question_count: int = 0
+    smartscope_analysis_id: Optional[UUID]
+    ai_confidence_score: Optional[float]
+    created_at: datetime
+    updated_at: datetime
+    published_at: Optional[datetime]
+    closed_at: Optional[datetime]
+
+    class Config:
+        use_enum_values = True
+
+
+class ProjectListResponse(BaseModel):
+    """Paginated response for project listings."""
+
+    projects: List[Project]
+    total: int
+    page: int
+    per_page: int
+    has_next: bool
+    has_prev: bool
+
+
+class ProjectFilter(BaseModel):
+    """Filters that can be applied when listing projects."""
+
+    search: Optional[str] = None
+    status: Optional[ProjectStatus] = None
+    category: Optional[ProjectCategory] = None
+    urgency: Optional[ProjectUrgency] = None
+    property_id: Optional[UUID] = None
+
+
+class ProjectStatusUpdate(BaseModel):
+    """Request payload for status transitions."""
+
+    status: ProjectStatus
+
+
+class ProjectPublishRequest(BaseModel):
+    """Request payload when publishing a project."""
+
+    send_notifications: bool = True
+    notify_email: Optional[EmailStr] = None
+
+
+__all__ = [
+    "BudgetRange",
+    "Project",
+    "ProjectBase",
+    "ProjectCategory",
+    "ProjectCreate",
+    "ProjectFilter",
+    "ProjectListResponse",
+    "ProjectPublishRequest",
+    "ProjectStatus",
+    "ProjectStatusUpdate",
+    "ProjectUpdate",
+    "ProjectUrgency",
+    "VirtualAccessInfo",
+]

--- a/api/models/user.py
+++ b/api/models/user.py
@@ -1,0 +1,23 @@
+"""User models used for authentication context within the API."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class User(BaseModel):
+    """Representation of an authenticated user returned by dependencies."""
+
+    id: UUID
+    email: EmailStr
+    full_name: Optional[str] = None
+    role: str
+    organization_id: Optional[UUID] = None
+    is_active: bool = True
+    created_at: datetime
+    updated_at: datetime
+
+
+__all__ = ["User"]

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,1 +1,5 @@
-# Routers module
+"""Router package exports."""
+
+from . import auth, properties, projects
+
+__all__ = ["auth", "properties", "projects"]

--- a/api/routers/projects.py
+++ b/api/routers/projects.py
@@ -1,0 +1,113 @@
+"""Project creation and management API endpoints."""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, status
+
+from ..dependencies import get_current_user
+from ..models.project import (
+    Project,
+    ProjectCreate,
+    ProjectFilter,
+    ProjectListResponse,
+    ProjectStatusUpdate,
+    ProjectUpdate,
+)
+from ..models.user import User
+from ..services.project_service import ProjectService
+
+router = APIRouter(prefix="/projects", tags=["Projects"])
+
+
+@router.post("/", response_model=Project, status_code=status.HTTP_201_CREATED)
+async def create_project(
+    project_data: ProjectCreate,
+    current_user: User = Depends(get_current_user),
+    service: ProjectService = Depends(lambda: ProjectService()),
+) -> Project:
+    """Create a new maintenance project."""
+    return await service.create_project(project_data, current_user)
+
+
+@router.get("/", response_model=ProjectListResponse)
+async def list_projects(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    search: Optional[str] = Query(None, max_length=100),
+    status_filter: Optional[str] = Query(None, alias="status"),
+    category: Optional[str] = None,
+    urgency: Optional[str] = None,
+    property_id: Optional[UUID] = None,
+    current_user: User = Depends(get_current_user),
+    service: ProjectService = Depends(lambda: ProjectService()),
+) -> ProjectListResponse:
+    """List projects visible to the authenticated user."""
+    filters = ProjectFilter(
+        search=search,
+        status=status_filter,
+        category=category,
+        urgency=urgency,
+        property_id=property_id,
+    )
+
+    projects, total = await service.list_projects(
+        filters=filters,
+        current_user=current_user,
+        page=page,
+        per_page=per_page,
+    )
+
+    return ProjectListResponse(
+        projects=projects,
+        total=total,
+        page=page,
+        per_page=per_page,
+        has_next=page * per_page < total,
+        has_prev=page > 1,
+    )
+
+
+@router.get("/{project_id}", response_model=Project)
+async def get_project(
+    project_id: UUID,
+    current_user: User = Depends(get_current_user),
+    service: ProjectService = Depends(lambda: ProjectService()),
+) -> Project:
+    """Retrieve a single project by ID."""
+    return await service.get_project(project_id, current_user)
+
+
+@router.put("/{project_id}", response_model=Project)
+async def update_project(
+    project_id: UUID,
+    update_payload: ProjectUpdate,
+    current_user: User = Depends(get_current_user),
+    service: ProjectService = Depends(lambda: ProjectService()),
+) -> Project:
+    """Update an existing project."""
+    return await service.update_project(project_id, update_payload, current_user)
+
+
+@router.patch("/{project_id}/status", response_model=Project)
+async def update_project_status(
+    project_id: UUID,
+    status_payload: ProjectStatusUpdate,
+    current_user: User = Depends(get_current_user),
+    service: ProjectService = Depends(lambda: ProjectService()),
+) -> Project:
+    """Transition a project to a new lifecycle status."""
+    return await service.update_status(project_id, status_payload.status, current_user)
+
+
+@router.delete("/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_project(
+    project_id: UUID,
+    current_user: User = Depends(get_current_user),
+    service: ProjectService = Depends(lambda: ProjectService()),
+) -> None:
+    """Delete a draft project."""
+    await service.delete_project(project_id, current_user)
+
+
+__all__ = ["router"]

--- a/api/services/project_service.py
+++ b/api/services/project_service.py
@@ -1,0 +1,330 @@
+"""Business logic for the project creation feature."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from supabase import Client
+
+from ..models.project import (
+    Project,
+    ProjectCreate,
+    ProjectFilter,
+    ProjectStatus,
+    ProjectUpdate,
+)
+from ..models.user import User
+from .supabase import SupabaseService
+
+
+class ProjectService:
+    """Encapsulates project specific data access and validation logic."""
+
+    def __init__(self, supabase: Optional[Client] = None) -> None:
+        self.supabase = supabase or SupabaseService.get_client()
+
+    async def create_project(self, payload: ProjectCreate, current_user: User) -> Project:
+        """Create a new project after verifying permissions and inputs."""
+        self._ensure_creator_permissions(current_user)
+
+        property_record = self._fetch_property(payload.property_id)
+        self._verify_property_access(property_record, current_user)
+
+        project_dict = self._build_project_insert_dict(payload, current_user)
+
+        result = self.supabase.table("projects").insert(project_dict).execute()
+        if not result.data:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create project",
+            )
+
+        return Project(**result.data[0])
+
+    async def get_project(self, project_id: UUID, current_user: User) -> Project:
+        """Retrieve a single project ensuring the requester has access."""
+        result = (
+            self.supabase.table("projects")
+            .select("*")
+            .eq("id", str(project_id))
+            .limit(1)
+            .execute()
+        )
+
+        if not result.data:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Project not found",
+            )
+
+        project_record = result.data[0]
+        property_record = self._fetch_property(UUID(project_record["property_id"]))
+        self._verify_property_access(property_record, current_user)
+
+        return Project(**project_record)
+
+    async def list_projects(
+        self,
+        filters: ProjectFilter,
+        current_user: User,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> Tuple[List[Project], int]:
+        """Return projects visible to the current user with pagination."""
+        property_ids = self._get_accessible_property_ids(current_user)
+        if not property_ids:
+            return [], 0
+
+        query = self.supabase.table("projects").select("*", count="exact")
+        query = query.in_("property_id", property_ids)
+
+        if filters.status:
+            query = query.eq("status", filters.status.value)
+        if filters.category:
+            query = query.eq("category", filters.category.value)
+        if filters.urgency:
+            query = query.eq("urgency", filters.urgency.value)
+        if filters.property_id:
+            if str(filters.property_id) not in property_ids:
+                return [], 0
+            query = query.eq("property_id", str(filters.property_id))
+        if filters.search:
+            like = f"%{filters.search}%"
+            query = query.or_(
+                f"title.ilike.{like},description.ilike.{like}"
+            )
+
+        offset = (page - 1) * per_page
+        query = query.range(offset, offset + per_page - 1)
+        query = query.order("created_at", desc=True)
+
+        result = query.execute()
+
+        projects = [Project(**record) for record in result.data]
+        total = result.count or 0
+
+        return projects, total
+
+    async def update_project(
+        self,
+        project_id: UUID,
+        payload: ProjectUpdate,
+        current_user: User,
+    ) -> Project:
+        """Update a project when the user has permission."""
+        existing = await self.get_project(project_id, current_user)
+        update_payload = self._build_project_update_dict(payload)
+
+        if not update_payload:
+            return existing
+
+        result = (
+            self.supabase.table("projects")
+            .update(update_payload)
+            .eq("id", str(project_id))
+            .execute()
+        )
+
+        if not result.data:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to update project",
+            )
+
+        return Project(**result.data[0])
+
+    async def update_status(
+        self,
+        project_id: UUID,
+        status_update: ProjectStatus,
+        current_user: User,
+    ) -> Project:
+        """Update a project's lifecycle status."""
+        await self.get_project(project_id, current_user)
+
+        update_dict: Dict[str, object] = {
+            "status": status_update.value,
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+
+        if status_update == ProjectStatus.OPEN_FOR_BIDS:
+            update_dict["published_at"] = datetime.utcnow().isoformat()
+        if status_update in {ProjectStatus.BIDDING_CLOSED, ProjectStatus.CANCELLED}:
+            update_dict["closed_at"] = datetime.utcnow().isoformat()
+
+        result = (
+            self.supabase.table("projects")
+            .update(update_dict)
+            .eq("id", str(project_id))
+            .execute()
+        )
+
+        if not result.data:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to update project status",
+            )
+
+        return Project(**result.data[0])
+
+    async def delete_project(self, project_id: UUID, current_user: User) -> None:
+        """Delete a project that is still in draft form."""
+        project = await self.get_project(project_id, current_user)
+        if project.status != ProjectStatus.DRAFT:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Only draft projects can be deleted",
+            )
+
+        result = (
+            self.supabase.table("projects")
+            .delete()
+            .eq("id", str(project_id))
+            .execute()
+        )
+
+        if not result.data:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to delete project",
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_creator_permissions(self, current_user: User) -> None:
+        if current_user.role not in {"admin", "manager"}:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only admins or managers can create projects",
+            )
+
+    def _fetch_property(self, property_id: UUID) -> Dict[str, object]:
+        result = (
+            self.supabase.table("properties")
+            .select("id, organization_id, manager_id")
+            .eq("id", str(property_id))
+            .limit(1)
+            .execute()
+        )
+
+        if not result.data:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Property not found",
+            )
+
+        return result.data[0]
+
+    def _verify_property_access(
+        self, property_record: Dict[str, object], current_user: User
+    ) -> None:
+        organization_id = property_record.get("organization_id")
+        manager_id = property_record.get("manager_id")
+
+        if current_user.organization_id and organization_id:
+            if str(current_user.organization_id) != organization_id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You cannot modify projects for another organization",
+                )
+
+        if current_user.role == "manager" and manager_id and manager_id != str(current_user.id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Managers can only manage their assigned properties",
+            )
+
+    def _build_project_insert_dict(
+        self, payload: ProjectCreate, current_user: User
+    ) -> Dict[str, object]:
+        now_iso = datetime.utcnow().isoformat()
+        status_value = payload.status.value
+
+        if payload.publish:
+            status_value = ProjectStatus.OPEN_FOR_BIDS.value
+
+        project_dict: Dict[str, object] = {
+            "property_id": str(payload.property_id),
+            "created_by": str(current_user.id),
+            "title": payload.title,
+            "description": payload.description,
+            "category": payload.category.value,
+            "urgency": payload.urgency.value,
+            "bid_deadline": payload.bid_deadline.isoformat(),
+            "preferred_start_date": payload.preferred_start_date.isoformat()
+            if payload.preferred_start_date
+            else None,
+            "completion_deadline": payload.completion_deadline.isoformat()
+            if payload.completion_deadline
+            else None,
+            "budget_min": payload.budget_min,
+            "budget_max": payload.budget_max,
+            "budget_range": payload.budget_range.value if payload.budget_range else None,
+            "insurance_required": payload.insurance_required,
+            "license_required": payload.license_required,
+            "minimum_bids": payload.minimum_bids,
+            "is_open_bidding": payload.is_open_bidding,
+            "virtual_access": payload.virtual_access.dict(exclude_none=True)
+            if payload.virtual_access
+            else None,
+            "location_details": payload.location_details,
+            "special_conditions": payload.special_conditions,
+            "status": status_value,
+            "updated_at": now_iso,
+        }
+
+        if payload.publish:
+            project_dict["published_at"] = now_iso
+
+        return project_dict
+
+    def _build_project_update_dict(self, payload: ProjectUpdate) -> Dict[str, object]:
+        update_dict: Dict[str, object] = {}
+        data = payload.dict(exclude_unset=True)
+
+        for key, value in data.items():
+            if value is None:
+                update_dict[key] = None
+                continue
+
+            if key in {"category", "urgency", "status"}:
+                update_dict[key] = value.value  # Enum to str
+            elif key in {"bid_deadline"}:
+                update_dict[key] = value.isoformat()
+            elif key in {"preferred_start_date", "completion_deadline"}:
+                update_dict[key] = value.isoformat() if value else None
+            elif key == "budget_range":
+                update_dict[key] = value.value
+            elif key == "virtual_access":
+                update_dict[key] = value.dict(exclude_none=True)
+            else:
+                update_dict[key] = value
+
+        if update_dict:
+            update_dict["updated_at"] = datetime.utcnow().isoformat()
+
+        return update_dict
+
+    def _get_accessible_property_ids(self, current_user: User) -> List[str]:
+        if not current_user.organization_id:
+            return []
+
+        query = (
+            self.supabase.table("properties")
+            .select("id")
+            .eq("organization_id", str(current_user.organization_id))
+            .eq("deleted_at", None)
+        )
+
+        if current_user.role == "manager":
+            query = query.eq("manager_id", str(current_user.id))
+
+        result = query.execute()
+        return [record["id"] for record in result.data]
+
+
+__all__ = ["ProjectService"]


### PR DESCRIPTION
## Summary
- introduce Pydantic models for projects, including validation of budgets, timelines, and access metadata
- add a Supabase-backed project service and FastAPI router exposing project CRUD and status endpoints
- update application wiring and progress log to reflect the new project backend foundation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb337579cc832fbea78d440fea06b2