### PR TITLE
Use supabase singleton client in project service

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,12 +1,12 @@
 fastapi==0.109.0
 uvicorn[standard]==0.27.0
-supabase==2.3.0
+supabase==2.19.0
 pydantic==2.5.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
 email-validator==2.1.0
 python-dotenv==1.0.0
-httpx==0.25.2
+httpx==0.28.1
 pytest==7.4.4
 pytest-asyncio==0.21.1

--- a/api/services/project_service.py
+++ b/api/services/project_service.py
@@ -17,14 +17,14 @@ from ..models.project import (
     ProjectUpdate,
 )
 from ..models.user import User
-from .supabase import SupabaseService
+from .supabase import supabase_service
 
 
 class ProjectService:
     """Encapsulates project specific data access and validation logic."""
 
     def __init__(self, supabase: Optional[Client] = None) -> None:
-        self.supabase = supabase or SupabaseService.get_client()
+        self.supabase = supabase or supabase_service.client
 
     async def create_project(self, payload: ProjectCreate, current_user: User) -> Project:
         """Create a new project after verifying permissions and inputs."""


### PR DESCRIPTION
## Summary
- update the project service to pull its Supabase client from the shared `supabase_service` singleton instead of calling a nonexistent helper
- bump Supabase and httpx dependency pins so the API requirements resolve without conflicts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb48ca4f04832f8e96d88c9f98c439