### PR TITLE
Fix Supabase client usage in dependencies and property routes

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from .config import settings
 from .models.user import User
-from .services.supabase import SupabaseService
+from .services.supabase import supabase_service
 
 security = HTTPBearer()
 
@@ -44,7 +44,7 @@ async def get_current_user(
             )
         
         # Get user from database
-        supabase = SupabaseService.get_client()
+        supabase = supabase_service.client
         result = supabase.table('user_profiles').select('*').eq(
             'id', user_id
         ).execute()

--- a/api/services/property_service.py
+++ b/api/services/property_service.py
@@ -15,7 +15,7 @@ from ..models.property import (
     PropertyBulkCreate, PropertyImport, PropertyExport,
     PropertyType, PropertyStatus, PropertyCoordinates
 )
-from .supabase import SupabaseService
+from .supabase import supabase_service
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class PropertyService:
     
     def __init__(self, supabase: Client = None):
         """Initialize property service."""
-        self.supabase = supabase or SupabaseService.get_client()
+        self.supabase = supabase or supabase_service.client
         self.geocoding_api_key = None  # Set from environment
     
     async def create_property(


### PR DESCRIPTION
## Summary
- update shared dependencies and property service to reuse the Supabase singleton client
- inject the singleton client into property group routes to avoid AttributeError at runtime

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb7d6f4ff8832fb858801f24971b93