### PR TITLE
Fix supabase singleton usage in auth dependencies and property routes

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -7,9 +7,9 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt
 from datetime import datetime
 
-from .config import settings
-from .models.user import User
-from .services.supabase import supabase_service
+from api.config import settings
+from api.models.user import User
+from api.services.supabase import supabase_service
 
 security = HTTPBearer()
 

--- a/api/routers/properties.py
+++ b/api/routers/properties.py
@@ -16,10 +16,10 @@ from ..models.property import (
 )
 from supabase import Client
 
-from ..services.property_service import PropertyService
-from ..services.supabase import supabase_service
-from ..dependencies import get_current_user, get_organization_id
-from ..models.user import User
+from api.services.property_service import PropertyService
+from api.services.supabase import supabase_service
+from api.dependencies import get_current_user, get_organization_id
+from api.models.user import User
 
 router = APIRouter(prefix="/properties", tags=["Properties"])
 

--- a/api/services/property_service.py
+++ b/api/services/property_service.py
@@ -15,7 +15,7 @@ from ..models.property import (
     PropertyBulkCreate, PropertyImport, PropertyExport,
     PropertyType, PropertyStatus, PropertyCoordinates
 )
-from .supabase import supabase_service
+from api.services.supabase import supabase_service
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure shared auth dependency pulls the supabase singleton client from `api.services.supabase`
- align property service and router imports to use the singleton client for property group operations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb7f929ef8832f9518b4d19bf8fb25