### PR TITLE
Fix syntax errors in auto-rebase Codex ping steps

### DIFF
--- a/.github/workflows/auto-rebase-and-autofix.yml
+++ b/.github/workflows/auto-rebase-and-autofix.yml
@@ -159,13 +159,15 @@ jobs:
       - name: Generate conflict report & ping Codex
         if: steps.conf.outputs.count != '0'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ matrix.pr.number }}
         with:
           script: |
             const fs = require('fs');
             const files = fs.readFileSync('/tmp/conflicts','utf8').trim().split('\n').filter(Boolean);
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
-            const prnum = ${{ matrix.pr.number }};
+            const prnum = Number(process.env.PR_NUMBER);
             const body = [
               '⚠️ Auto-rebase hit merge conflicts:',
               ...files.map(f=>`- \`${f}\``),
@@ -296,13 +298,15 @@ jobs:
       - name: Comment conflicts & ping Codex (manual path)
         if: steps.conf.outputs.count != '0'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const fs = require('fs');
             const files = fs.readFileSync('/tmp/conflicts','utf8').trim().split('\n').filter(Boolean);
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
-            const prnum = Number("${{ steps.pr.outputs.number }}");
+            const prnum = Number(process.env.PR_NUMBER);
             const body = [
               '⚠️ Auto-rebase (manual) hit merge conflicts:',
               ...files.map(f=>`- \`${f}\``),
@@ -314,5 +318,4 @@ jobs:
             await github.rest.pulls.requestReviewers({
               owner, repo, pull_number: prnum,
               reviewers: [process.env.CODEX_HANDLE.replace(/^@/,'')]
-            }).catch(()=>{});  # fine if bot can't be reviewer
-
+            }).catch(()=>{});  // fine if bot can't be reviewer


### PR DESCRIPTION
## Summary
- Fix JavaScript syntax errors in the auto-rebase-and-autofix.yml workflow
- Replace inline GitHub expressions `${{ matrix.pr.number }}` with environment variables `process.env.PR_NUMBER` to avoid `SyntaxError: Invalid or unexpected token`
- Ensures Codex ping functionality works properly when merge conflicts are detected

## Problem
The workflow was failing with syntax errors when trying to ping @chatgpt-codex-connector due to GitHub expressions being used inside JavaScript template literals. This prevented the automated conflict resolution system from properly notifying Codex about conflicts.

## Solution
- Added `env:` blocks to pass PR numbers as environment variables
- Updated JavaScript code to use `process.env.PR_NUMBER` instead of inline expressions
- Fixed both the scheduled/automatic ping (update job) and manual ping (one-pr job) paths

## Testing
This fixes the core issue that was preventing the automated Codex integration from working when merge conflicts occur. Once merged, the workflow should properly ping Codex with conflict information for PRs like #15 that already have detected conflicts.