### PR TITLE
Fix Codex handle to use @codex instead of @chatgpt-codex-connector

### DIFF
--- a/.github/workflows/auto-rebase-and-autofix.yml
+++ b/.github/workflows/auto-rebase-and-autofix.yml
@@ -17,7 +17,7 @@ permissions:
   issues: write
 
 env:
-  CODEX_HANDLE: "@chatgpt-codex-connector"
+  CODEX_HANDLE: "@codex"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Fix Codex Integration

This PR fixes the critical issue where the automated conflict resolution system was pinging `@chatgpt-codex-connector` instead of `@codex`.

### Changes Made
- Updated `CODEX_HANDLE` environment variable from `"@chatgpt-codex-connector"` to `"@codex"` in `.github/workflows/auto-rebase-and-autofix.yml`

### Problem Solved
The automated workflow was posting comments with the wrong handle, so Codex wasn't actually receiving tasks when conflicts occurred. Only `@codex` triggers the Codex task system.

### Testing
After merging, test by creating a PR with conflicts to verify that:
1. The workflow detects conflicts
2. Posts comments with `@codex` (not `@chatgpt-codex-connector`)
3. Codex actually receives and processes the task

This should resolve the issue where "nothing automatically triggered" in Codex.