### PR TITLE
Critical fix: Correct API parameter in workflow

### DIFF
--- a/.github/workflows/auto-rebase-and-autofix.yml
+++ b/.github/workflows/auto-rebase-and-autofix.yml
@@ -276,7 +276,7 @@ jobs:
           script: |
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner, repo: context.repo.repo,
-              pull_request: context.payload.issue.number
+              pull_number: context.payload.issue.number
             });
             core.setOutput('number', pr.number);
             core.setOutput('ref', pr.head.ref);


### PR DESCRIPTION
## Urgent Fix

The workflow was failing because the GitHub API call was using the wrong parameter name.

## Changes
- Fixed API call in the `Get PR info` step: changed `pull_request` to `pull_number`

## Impact
This fix ensures the `/autofix` command actually works and can:
1. Successfully fetch PR information
2. Post conflict details to PRs
3. Enable end-to-end automated conflict resolution

## Testing
After merging, the `/autofix` command on PR #15 will finally work correctly.