### PR TITLE
Fix apply-codex-resolutions workflow syntax issues

### DIFF
--- a/.github/workflows/apply-codex-resolutions.yml
+++ b/.github/workflows/apply-codex-resolutions.yml
@@ -1,71 +1,73 @@
- name: Apply Codex resolutions
+name: Apply Codex resolutions
 
-  on:
-    issue_comment:
-      types: [created]
+on:
+  issue_comment:
+    types: [created]
 
-  permissions:
-    contents: write
-    pull-requests: write
+permissions:
+  contents: write
+  pull-requests: write
 
-  jobs:
-    apply:
-      if: >
-        github.event.issue.pull_request != null &&
-        (
-          github.event.comment.user.login == 'chatgpt-codex-connector[bot]' ||
-          contains(github.event.comment.body, '```resolved:')
-        )
-      runs-on: ubuntu-latest
-      steps:
-        - name: Get PR info
-          id: pr
-          uses: actions/github-script@v7
-          with:
-            script: |
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.issue.number
-              });
-              core.setOutput('ref', pr.head.ref);
+jobs:
+  apply:
+    if: >
+      github.event.issue.pull_request != null &&
+      (
+        github.event.comment.user.login == 'chatgpt-codex-connector[bot]' ||
+        contains(github.event.comment.body, '```resolved:')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number
+            });
+            core.setOutput('ref', pr.head.ref);
 
-        - uses: actions/checkout@v4
-          with:
-            ref: ${{ steps.pr.outputs.ref }}
-            fetch-depth: 0
-            token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
-        - name: Extract resolved files from comment and write to tree
-          id: write
-          run: |
-            python - <<'PY'
-            import os, re, pathlib, sys, json
-            body = os.environ["BODY"]
-            # look for blocks like ```resolved:path/to/file.py\n<content>\n```
-            pattern = re.compile(r"```resolved:([^\n`]+)\n(.*?)\n```", re.S)
-            matches = pattern.findall(body)
-            if not matches:
-                print("::set-output name=changed::0")
-                sys.exit(0)
-            changed = 0
-            for path,content in matches:
-                p = pathlib.Path(path)
-                p.parent.mkdir(parents=True, exist_ok=True)
-                p.write_text(content, encoding="utf-8")
-                changed += 1
-            print(f"wrote {changed} files")
-            print(f"::set-output name=changed::{changed}")
-            PY
-          env:
-            BODY: ${{ github.event.comment.body }}
+      - name: Extract resolved files from comment and write to tree
+        id: write
+        run: |
+          python - <<'PY'
+          import os, re, pathlib, sys, json
+          body = os.environ["BODY"]
+          # look for blocks like ```resolved:path/to/file.py\n<content>\n```
+          pattern = re.compile(r"```resolved:([^\n`]+)\n(.*?)\n```", re.S)
+          matches = pattern.findall(body)
+          if not matches:
+              print("No resolved blocks found")
+              with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                  f.write("changed=0\n")
+              sys.exit(0)
+          changed = 0
+          for path,content in matches:
+              p = pathlib.Path(path)
+              p.parent.mkdir(parents=True, exist_ok=True)
+              p.write_text(content, encoding="utf-8")
+              changed += 1
+          print(f"wrote {changed} files")
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"changed={changed}\n")
+          PY
+        env:
+          BODY: ${{ github.event.comment.body }}
 
-        - name: Commit and push
-          if: steps.write.outputs.changed != '0'
-          run: |
-            git config user.name  "codex-applier-bot"
-            git config user.email "codex-applier-bot@users.noreply.github.com"
-            git add -A
-            git commit -m "apply codex resolutions from comment ${{
-  github.event.comment.id }}"
-            git push
+      - name: Commit and push
+        if: steps.write.outputs.changed != '0'
+        run: |
+          git config user.name  "codex-applier-bot"
+          git config user.email "codex-applier-bot@users.noreply.github.com"
+          git add -A
+          git commit -m "apply codex resolutions from comment ${{ github.event.comment.id }}"
+          git push


### PR DESCRIPTION
## Summary
- Fixed YAML indentation issues (removed leading spaces before `name:` and `on:`)
- Updated deprecated `::set-output` syntax to use `GITHUB_OUTPUT` environment file
- These fixes ensure the workflow will properly trigger on issue_comment events

## Why it wasn't working
1. The workflow had invalid YAML with leading spaces before top-level keys
2. The deprecated output syntax would cause issues in newer GitHub Actions runners

## Testing
After merging, the workflow should:
1. Trigger when Codex AI posts comments with `resolved:` blocks
2. Apply the resolved code to the PR branch
3. Push the changes automatically