### PR TITLE
Fix duplicate imports and API errors in 5 API files

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -37,13 +37,6 @@ class Settings(BaseSettings):
     rate_limit_period: int = 3600
 
     # OpenAI / SmartScope
-    openai_api_key: str = ""
-    smartscope_model: str = "gpt-4-vision-preview"
-    smartscope_max_output_tokens: int = 1200
-    smartscope_temperature: float = 0.2
-    smartscope_confidence_threshold: float = 0.75
-
-    # OpenAI / SmartScope
     openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
     smartscope_model: str = os.getenv("SMARTSCOPE_MODEL", "gpt-4.1-mini")
     smartscope_max_output_tokens: int = int(

--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,8 @@
 import logging
 from contextlib import asynccontextmanager
 
-from config import settings
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from middleware.rate_limit import rate_limit_middleware
-from routers import auth, projects, properties, smartscope
-from services.supabase import supabase_service
 
 from .config import settings
 from .middleware.rate_limit import rate_limit_middleware
@@ -90,7 +86,6 @@ app.include_router(
     prefix="/api",
     tags=["SmartScope AI"],
 )
-tags = ["SmartScope AI"]
 
 
 # Health check endpoint

--- a/api/routers/smartscope.py
+++ b/api/routers/smartscope.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
-from models.user import User
-from services.smartscope_service import SmartScopeService
 
 from ..dependencies import get_current_user
-from ..models.smartscope import (AccuracyMetrics, AnalysisListResponse,
-                                 AnalysisRequest, FeedbackRequest,
-                                 SmartScopeAnalysis, dependencies, from,
-                                 get_current_user, import, models.smartscope)
+from ..models.smartscope import (
+    AccuracyMetrics,
+    AnalysisListResponse,
+    AnalysisRequest,
+    FeedbackRequest,
+    SmartScopeAnalysis,
+)
 from ..models.user import User
 from ..services.smartscope_service import SmartScopeService
 


### PR DESCRIPTION
## Summary
This PR fixes duplicate import statements and API errors in 5 API files that were corrupted with merge artifacts from PR #15.

## Files Fixed
- **api/config.py**: Removed duplicate OpenAI config block (lines 39-44)
- **api/main.py**: Removed duplicate imports and orphan variable
- **api/routers/smartscope.py**: Cleaned corrupted import statements with random keywords
- **api/services/smartscope_service.py**: Removed duplicate import blocks
- **api/services/openai_vision.py**: 
  - Fixed duplicate imports (lines 15-31)
  - Fixed OpenAI API calls (responses.create → chat.completions.create)
  - Updated payload format for OpenAI chat completions API

## Changes Made
1. Removed all duplicate import blocks
2. Fixed corrupted import statements with extra "from, import" keywords
3. Updated OpenAI Vision API to use correct chat.completions format
4. Fixed response extraction to match OpenAI API structure

## Testing
- All imports now resolve correctly
- OpenAI API calls use the correct format
- No duplicate code remains

This is the first of several smaller PRs to resolve issues from PR #15.