### PR TITLE
Add missing auto-update-prs workflow

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,0 +1,21 @@
+name: Auto-update PRs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    steps:
+      - name: Auto-update open PRs
+        uses: adRise/update-pr-branch@v0.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          sort: created
+          direction: desc


### PR DESCRIPTION
## Summary
This PR adds the missing `.github/workflows/auto-update-prs.yml` workflow file that was referenced in PR #15 but missing from the main branch.

## File Added
- **.github/workflows/auto-update-prs.yml**: GitHub Actions workflow that automatically updates open pull requests when the main branch is updated

## Workflow Features
- Triggers on push to main branch
- Updates all open PRs to keep them current with main
- Uses `adRise/update-pr-branch@v0.7.0` action
- Sorts PRs by creation date (newest first)
- Has proper permissions for content reading and PR writing

## Benefits
- Reduces merge conflicts by keeping PRs current
- Automates manual PR maintenance tasks  
- Ensures code reviews are always against latest main branch

This resolves one of the missing files from the PR #15 analysis.