### PR TITLE
docs: update tasks tracker with actual build audit

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -1,23 +1,67 @@
 ---
-description: Generate an ordered, actionable task list from the implementation plan
+description: Instabids Management build audit and remaining work tracker
 ---
 
-# /tasks Command
+# Current Build Audit
 
-Given the implementation plan, do this:
+## ✅ Implemented in the Repository Today
+- Extensive documentation set (`README.md`, `CLAUDE.md`, `specs/**`) that captures product vision, feature specs, and implementation guides.
+- Database migrations through `004_marketplace_core.sql` defining marketplace tables (projects, quotes, contractors, smartscope_analyses, etc.) plus the earlier property schemas.
+- FastAPI application scaffolding with routers for authentication, properties, projects, and SmartScope along with corresponding Pydantic models and Supabase-backed services.
+- SmartScope service layer, OpenAI Vision integration wrapper, and cost tracking helper stubs wired into the API (no concrete provider credentials supplied).
+- Supabase service singleton and settings module that load environment configuration for backend usage (currently populated with placeholder keys that must be replaced).
+- Next.js frontend scaffold with Auth context, authentication forms, and placeholder dashboard/property components.
+- Initial automated test scaffolding under `api/tests/` covering auth flows, Supabase integration surface, and SmartScope service behavior.
+- Developer tooling scripts for starting the API (`start_server.py`), running combined tests (`run_tests.py`), and lint/test configuration files for both API and web apps.
 
-1. Load the plan from `specs/[feature-name]/plan.md`
-2. Generate numbered tasks following this pattern:
-   - Contract tests first (TDD approach)
-   - Models/entities creation
-   - Service layer implementation  
-   - API/UI implementation
-   - Integration tests
-3. Mark tasks that can be done in parallel with [P]
-4. Save ordered task list to `specs/[feature-name]/tasks.md`
-5. Each task should be specific and actionable:
-   - "Create User model with email validation"
-   - "Write contract test for POST /api/users"
-   - "Implement password reset service"
+## 🚧 High-Priority Gaps & Follow-Up Tasks
 
-Target: 25-30 specific, ordered tasks ready for execution.
+### Platform & DevOps
+1. Replace placeholder Supabase/AI credentials in `api/config.py` with secure environment management and document setup for local + production usage.
+2. Provide infrastructure scripts or instructions for provisioning required storage buckets, Edge Functions, and webhook endpoints referenced in specs but absent from the repo.
+3. Implement CI workflows (lint, tests, type-check) and ensure both API and web apps have reproducible dependency locks.
+
+### Authentication & User Management
+4. Finish email verification flow—`/verify-email` currently returns success without persisting any state or hitting Supabase verification endpoints.
+5. Wire `/logout`, `/profile`, and password reset endpoints to real Supabase auth/session state instead of placeholders; add negative-path tests.
+6. Ensure organization creation/association logic matches marketplace rules (role enforcement, invitations) and surface the flows in the frontend (only auth forms exist today).
+
+### Property Management
+7. Connect property components in `web/src/components/properties` to live API data, add create/edit flows, and render property metadata (currently just UI shells).
+8. Implement property import/export, audit logging, and group membership management endpoints promised by the service layer but lacking routers/tests/frontends.
+9. Add end-to-end tests (API + UI) verifying property CRUD, bulk operations, and authorization boundaries.
+
+### Project Creation
+10. Extend `ProjectService` to cover full spec requirements: media upload orchestration, invitation automation, SmartScope trigger hooks, and contractor-matching scoring.
+11. Build Next.js project creation wizard, validation, and file upload experience; no frontend exists for projects today beyond placeholders.
+12. Introduce background processing/queues for project lifecycle events (notifications, SmartScope requests) as called out in the specs.
+
+### Contractor Onboarding
+13. Implement contractor domain models, Supabase tables usage, and FastAPI routes—no onboarding backend or UI exists beyond SQL definitions.
+14. Deliver contractor-facing Next.js flows (registration, credential upload, availability) and tie them to verification workflows.
+15. Add compliance checks, document storage integration, and automated approval pipelines described in the onboarding specification.
+
+### Quote Submission
+16. Build ingestion services for PDF uploads, email processing, manual entry, and photo capture—only database schema exists at present.
+17. Implement quote standardization engine (OCR/NLP adapters, normalization rules, AI confidence scoring) and persist results.
+18. Create property manager UI for quote comparison, evaluation, and award selection; no frontend or API endpoints currently cover these tasks.
+
+### SmartScope AI
+19. Provide actual OpenAI API key management, request throttling, and error fallbacks; existing code will raise without environment configuration.
+20. Implement webhook/storage handling for photo ingestion and ensure SmartScope results post back into projects/notifications per spec.
+21. Expand test coverage to include mocked OpenAI responses, cost tracking assertions, and Supabase persistence validation.
+
+### Frontend Experience & Navigation
+22. Build global layout, navigation, and routing guard logic connecting auth state to protected routes (dashboard is static today).
+23. Implement project, property, contractor, and quote views/pages with real data fetching hooks and optimistic updates.
+24. Add design system components, loading/error states, and responsiveness as described in UI guides—current UI is minimal and unaudited.
+
+### Testing, QA, and Tooling
+25. Establish comprehensive pytest suites for every router/service plus contract tests for Supabase interactions; current coverage is sparse and lacks fixtures for new tables.
+26. Add Playwright or Cypress end-to-end tests for critical user journeys (auth, property CRUD, project creation, quote review).
+27. Integrate linting/formatting/type-check commands into both API (`ruff`, `mypy`) and web (`eslint`, `tsc`) pipelines and make sure they pass.
+
+### Documentation & Tracking
+28. Reconcile `PROGRESS.md`, migration trackers, and feature specs with the actual codebase so status reports no longer overstate completion.
+29. Document local development workflows for running FastAPI + Next.js together, including required environment variables and mock services.
+30. Maintain updated task breakdowns within each `specs/[feature]/tasks.md` reflecting real progress as features land.


### PR DESCRIPTION
## Summary
- replace the placeholder /tasks command instructions with an up-to-date build status overview
- document which platform components exist in the repo today across backend, frontend, and docs
- list the remaining high-priority work items so specs and progress trackers reflect reality

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68cee53576a4832f8cbaa12cd8f193ef