### PR TITLE
Fix: Correct api/main.py merge conflict resolution

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -14,10 +14,10 @@ os.environ["SUPABASE_SERVICE_KEY"] = (
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxtYnB2a2ZjZmhkZmFpaGlnZmR1Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1ODEyODM1MiwiZXhwIjoyMDczNzA0MzUyfQ.SSyQjgk5SSgptLXjKM6tNi_ZFZln9tA3FMJYmF3qSz0"
 )
 
-from config import settings
-from middleware.rate_limit import rate_limit_middleware
-from routers import auth, projects, properties, smartscope
-from services.supabase import supabase_service
+from .config import settings
+from .middleware.rate_limit import rate_limit_middleware
+from .routers import auth, projects, properties, quotes, smartscope
+from .services.supabase import supabase_service
 
 # Configure logging
 logging.basicConfig(
@@ -93,6 +93,12 @@ app.include_router(
     projects.router,
     prefix="/api",
     tags=["Projects"],
+)
+
+app.include_router(
+    quotes.router,
+    prefix="/api",
+    tags=["Quotes"],
 )
 
 app.include_router(


### PR DESCRIPTION
## Summary
This PR fixes the merge conflict in `api/main.py` that was incorrectly resolved by the automated system.

## Problem
The original PR #77 had a merge conflict in `api/main.py` where:
- **Main branch** had hardcoded Supabase environment variables (CRITICAL for production)
- **PR branch** had relative imports and quotes router

The automated Codex resolution incorrectly removed the Supabase environment variables, which would break production.

## Solution
This PR provides the correct merge resolution that:
- ✅ **Keeps** Supabase environment variables from main branch (CRITICAL)
- ✅ **Uses** relative imports from PR branch (`.config`, `.middleware`, `.routers`)
- ✅ **Includes** quotes router from PR branch
- ✅ **Maintains** all functionality from both branches

## Changes Made
```python
# KEPT from main branch (CRITICAL):
os.environ["SUPABASE_URL"] = "https://lmbpvkfcfhdfaihigfdu.supabase.co"
os.environ["SUPABASE_ANON_KEY"] = "..."
os.environ["SUPABASE_SERVICE_KEY"] = "..."

# ADOPTED from PR branch:
from .config import settings  # relative imports
from .routers import auth, projects, properties, quotes, smartscope  # includes quotes
```

## Testing
This resolution:
- Preserves production Supabase connection
- Maintains proper module structure with relative imports
- Includes all routers from the feature branch

## Related
- Fixes the incorrect resolution from PR #77
- Addresses the automated conflict resolution system limitations

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>