### PR TITLE
🚀 Add Manual Trigger to Automated Conflict Resolver

### DIFF
--- a/.github/workflows/auto-conflict-resolver-ACTUALLY-WORKING.yml
+++ b/.github/workflows/auto-conflict-resolver-ACTUALLY-WORKING.yml
@@ -3,6 +3,12 @@ name: Auto Conflict Resolver - FULLY AUTOMATED (ACTUALLY WORKING)
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to resolve conflicts for'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,7 +17,9 @@ permissions:
 
 jobs:
   auto-resolve-conflicts:
-    if: github.event.issue.pull_request != null && contains(github.event.comment.body, '/resolve-now')
+    if: |
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/resolve-now')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '')
     runs-on: ubuntu-latest
     
     steps:
@@ -29,7 +37,11 @@ jobs:
       - name: Get PR info
         id: pr_info
         run: |
-          PR_NUMBER=${{ github.event.issue.number }}
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PR_NUMBER=${{ github.event.inputs.pr_number }}
+          else
+            PR_NUMBER=${{ github.event.issue.number }}
+          fi
           PR_INFO=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}")
           HEAD_REF=$(echo "$PR_INFO" | jq -r .head.ref)


### PR DESCRIPTION
## 🎯 Purpose

Fix GitHub webhook issue preventing issue_comment events from triggering the automated conflict resolution workflow by adding a manual trigger option.

## ✨ Changes

- ✅ Add `workflow_dispatch` trigger with PR number input
- ✅ Support both issue comments and manual execution
- ✅ Update conditional logic to handle both trigger types  
- ✅ Enable testing when issue_comment webhooks fail

## 🔧 How it Works

**Issue Comment Trigger (when webhooks work):**
```
on:
  issue_comment:
    types: [created]
```
- Triggers automatically when `/resolve-now` is commented
- Uses `github.event.issue.number` to get PR number

**Manual Trigger (when webhooks fail):**
```
on:
  workflow_dispatch:
    inputs:
      pr_number:
        description: 'PR number to resolve conflicts for'
        required: true
        type: string
```
- Can be manually run from GitHub Actions tab
- Uses `github.event.inputs.pr_number` for PR number

## 🧪 Testing Plan

1. **Manual Test**: Run workflow manually with PR number 77
2. **Verify Detection**: Confirm all 7 conflicted files are found
3. **Verify Resolution**: Confirm intelligent conflict resolution works
4. **Verify Push**: Confirm changes are pushed back to PR branch
5. **Verify Comments**: Confirm status is posted to PR

## 🚨 Why This is Critical

GitHub's issue_comment webhooks are not triggering workflows in this repository, blocking the automated conflict resolution system. This manual trigger allows us to:

- Test the automated resolution logic immediately
- Bypass webhook delivery issues
- Provide fallback when comment triggers fail
- Maintain full automation capabilities

**This resolves the core blocking issue preventing automated conflict resolution from working.**